### PR TITLE
fix: make release notes workflow resilient when Claude Code App is not installed

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Write release notes with Claude
+        continue-on-error: true
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -47,6 +48,7 @@ jobs:
             Do NOT publish it yourself — a subsequent step will do that.
 
       - name: Publish release notes
+        if: ${{ hashFiles('release-notes.md') != '' }}
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the Write release notes with Claude step
- Add `if: ${{ hashFiles('release-notes.md') != '' }}` condition to Publish step to skip if notes weren't generated

This prevents the Release Notes workflow from failing when the Claude Code GitHub App is not installed on the repository.